### PR TITLE
Refactor composite function to handle function handles

### DIFF
--- a/@composite/composite.m
+++ b/@composite/composite.m
@@ -21,7 +21,7 @@ for n = 1:nargin
     case {'moebius','diskmap','hplmap','extermap','stripmap','rectmap',...
 	    'crdiskmap','crrectmap','riesurfmap','scmapinv'}
       f.maps{end+1} = map;
-    case 'inline'
+    case {'inline','function_handle'}
       if nargin(map) > 1
 	error('Inline functions must have only one argument.')
       else


### PR DESCRIPTION
I'm not sure if matlab's classes changed, but adding 'function_handle' here, makes the example code (seemingly correctly) run on Matlab 2024b